### PR TITLE
Dispatch rewrite

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -117,6 +117,16 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
 
+    trait TestHelpers {
+        fn load_constant(&mut self, x: usize, kk: u8);
+    }
+
+    impl TestHelpers for Processor {
+        fn load_constant(&mut self, x: usize, kk: u8) {
+            self.v[x] = kk;
+        }
+    }
+
     #[test]
     fn pc_starts_at_0x200() {
         let cpu = Processor::new();
@@ -140,7 +150,7 @@ mod tests {
     #[test]
     fn add_constant_to_register_normal() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x0, 1);
+        cpu.load_constant(0x0, 1);
         cpu.execute(0x7001);
         assert_eq!(2, cpu.v[0x0]);
         assert_eq!(0, cpu.v[0xF]);
@@ -149,7 +159,7 @@ mod tests {
     #[test]
     fn add_constant_to_register_overflow() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x0, 0xFF);
+        cpu.load_constant(0x0, 0xFF);
         cpu.execute(0x7001);
         assert_eq!(0, cpu.v[0x0]);
         assert_eq!(1, cpu.v[0xF]);
@@ -158,8 +168,8 @@ mod tests {
     #[test]
     fn add_register_to_register_normal() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x0, 1);
-        cpu.op_6xkk(0x1, 2);
+        cpu.load_constant(0x0, 1);
+        cpu.load_constant(0x1, 2);
         cpu.execute(0x8014);
         assert_eq!(3, cpu.v[0x0]);
         assert_eq!(0, cpu.v[0xF]);
@@ -168,8 +178,8 @@ mod tests {
     #[test]
     fn add_register_to_register_overflow() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x0, 0xFF);
-        cpu.op_6xkk(0x1, 1);
+        cpu.load_constant(0x0, 0xFF);
+        cpu.load_constant(0x1, 1);
         cpu.execute(0x8014);
         assert_eq!(0, cpu.v[0x0]);
         assert_eq!(1, cpu.v[0xF]);
@@ -214,7 +224,7 @@ mod tests {
     #[test]
     fn se_constant_skip() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x0, 32);
+        cpu.load_constant(0x0, 32);
         cpu.execute(0x3020);
         assert_eq!(0x204, cpu.pc);
     }
@@ -222,7 +232,7 @@ mod tests {
     #[test]
     fn se_constant_no_skip() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x0, 32);
+        cpu.load_constant(0x0, 32);
         cpu.execute(0x3021);
         assert_eq!(0x202, cpu.pc);
     }
@@ -230,7 +240,7 @@ mod tests {
     #[test]
     fn sne_constant_skip() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x0, 32);
+        cpu.load_constant(0x0, 32);
         cpu.execute(0x4021);
         assert_eq!(0x204, cpu.pc);
     }
@@ -238,7 +248,7 @@ mod tests {
     #[test]
     fn sne_constant_no_skip() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x0, 32);
+        cpu.load_constant(0x0, 32);
         cpu.execute(0x4020);
         assert_eq!(0x202, cpu.pc);
     }
@@ -246,8 +256,8 @@ mod tests {
     #[test]
     fn se_register_skip() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x0, 32);
-        cpu.op_6xkk(0x1, 32);
+        cpu.load_constant(0x0, 32);
+        cpu.load_constant(0x1, 32);
         cpu.execute(0x5010);
         assert_eq!(0x204, cpu.pc);
     }
@@ -255,8 +265,8 @@ mod tests {
     #[test]
     fn se_register_no_skip() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x0, 32);
-        cpu.op_6xkk(0x1, 33);
+        cpu.load_constant(0x0, 32);
+        cpu.load_constant(0x1, 33);
         cpu.execute(0x5010);
         assert_eq!(0x202, cpu.pc);
     }
@@ -264,7 +274,7 @@ mod tests {
     #[test]
     fn ld_register_to_register() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x0, 32);
+        cpu.load_constant(0x0, 32);
         cpu.execute(0x8100);
         assert_eq!(32, cpu.v[0x1]);
     }
@@ -272,8 +282,8 @@ mod tests {
     #[test]
     fn or_register_to_register() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x0, 0x55);
-        cpu.op_6xkk(0x1, 0x3C);
+        cpu.load_constant(0x0, 0x55);
+        cpu.load_constant(0x1, 0x3C);
         cpu.execute(0x8011);
         assert_eq!(0x7D, cpu.v[0x0]);
     }
@@ -281,8 +291,8 @@ mod tests {
     #[test]
     fn and_register_to_register() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x0, 0x55);
-        cpu.op_6xkk(0x1, 0x3C);
+        cpu.load_constant(0x0, 0x55);
+        cpu.load_constant(0x1, 0x3C);
         cpu.execute(0x8012);
         assert_eq!(0x14, cpu.v[0x0]);
     }
@@ -290,8 +300,8 @@ mod tests {
     #[test]
     fn xor_register_to_register() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x0, 0x55);
-        cpu.op_6xkk(0x1, 0x3C);
+        cpu.load_constant(0x0, 0x55);
+        cpu.load_constant(0x1, 0x3C);
         cpu.execute(0x8013);
         assert_eq!(0x69, cpu.v[0x0]);
     }
@@ -299,8 +309,8 @@ mod tests {
     #[test]
     fn sub_register_to_register_no_borrow() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x0, 21);
-        cpu.op_6xkk(0x1, 7);
+        cpu.load_constant(0x0, 21);
+        cpu.load_constant(0x1, 7);
         cpu.execute(0x8015);
         assert_eq!(14, cpu.v[0x0]);
         assert_eq!(1, cpu.v[0xF]);
@@ -309,8 +319,8 @@ mod tests {
     #[test]
     fn sub_register_to_register_borrow() {
         let mut cpu = Processor::new();
-        cpu.op_6xkk(0x1, 21);
-        cpu.op_6xkk(0x0, 7);
+        cpu.load_constant(0x1, 21);
+        cpu.load_constant(0x0, 7);
         cpu.execute(0x8015);
         assert_eq!(242, cpu.v[0x0]);
         assert_eq!(0, cpu.v[0xF]);

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -80,15 +80,23 @@ impl Processor {
         }
     }
 
-    fn op_5xy0(&mut self, x: usize, y: usize) {}
+    fn op_5xy0(&mut self, x: usize, y: usize) {
+        if self.v[x] == self.v[y] {
+            self.pc += 2;
+        }
+    }
 
     fn op_6xkk(&mut self, x: usize, kk: u8) {
         self.v[x] = kk;
     }
 
-    fn op_7xkk(&mut self, x: usize, kk: u8) {}
+    fn op_7xkk(&mut self, x: usize, kk: u8) {
+        self.v[x] += kk;
+    }
 
-    fn op_8xy0(&mut self, x: usize, y: usize) {}
+    fn op_8xy0(&mut self, x: usize, y: usize) {
+        self.v[x] = self.v[y];
+    }
 
     fn op_8xy1(&mut self, x: usize, y: usize) {
         self.v[x] |= self.v[y];
@@ -103,13 +111,19 @@ impl Processor {
     }
 
     fn op_8xy4(&mut self, x: usize, y: usize) {
+        self.add_register(x, self.v[y]);
+    }
+
+    fn op_8xy5(&mut self, x: usize, y: usize) {
+        self.add_register(x, u8::MAX - self.v[y] + 1);
+    }
+
+    fn add_register(&mut self, x: usize, kk: u8) {
         let mut value = self.v[x] as u16;
-        value += self.v[y] as u16;
+        value += kk as u16;
         self.v[0xF] = (value > 0xFF) as u8;
         self.v[x] = value as u8;
     }
-
-    fn op_8xy5(&mut self, x: usize, y: usize) {}
 }
 
 #[cfg(test)]

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -91,7 +91,7 @@ impl Processor {
     }
 
     fn op_7xkk(&mut self, x: usize, kk: u8) {
-        self.v[x] += kk;
+        self.add_with_overflow(x, kk);
     }
 
     fn op_8xy0(&mut self, x: usize, y: usize) {
@@ -111,14 +111,14 @@ impl Processor {
     }
 
     fn op_8xy4(&mut self, x: usize, y: usize) {
-        self.add_register(x, self.v[y]);
+        self.add_with_overflow(x, self.v[y]);
     }
 
     fn op_8xy5(&mut self, x: usize, y: usize) {
-        self.add_register(x, u8::MAX - self.v[y] + 1);
+        self.add_with_overflow(x, u8::MAX - self.v[y] + 1);
     }
 
-    fn add_register(&mut self, x: usize, kk: u8) {
+    fn add_with_overflow(&mut self, x: usize, kk: u8) {
         let mut value = self.v[x] as u16;
         value += kk as u16;
         self.v[0xF] = (value > 0xFF) as u8;


### PR DESCRIPTION
Change the instruction dispatching to using a `match` expression with nibbles. Rename dispatch instruction handlers to their opcode signature.